### PR TITLE
fix: `client.call` must use parameters as an object

### DIFF
--- a/packages/flipper-plugin-react-query-native-devtools/src/index.tsx
+++ b/packages/flipper-plugin-react-query-native-devtools/src/index.tsx
@@ -30,11 +30,11 @@ const ReactQueryDevtools: FunctionComponent<ReactQueryDevtoolsProps> = ({ client
   const query = queries.find((query: Query): boolean => query.queryHash === selectedQuery);
 
   const onQueryRefetch = (query: Query): void => {
-    client.call('query:refetch', query.queryHash);
+    client.call('query:refetch', { queryHash: query.queryHash });
   };
 
   const onQueryRemove = (query: Query): void => {
-    client.call('query:remove', query.queryHash);
+    client.call('query:remove', { queryHash: query.queryHash });
   };
 
   return (

--- a/packages/react-query-native-devtools/src/index.ts
+++ b/packages/react-query-native-devtools/src/index.ts
@@ -21,11 +21,11 @@ export function addPlugin(queryCache: QueryCache) {
         connection.send('queries', getQueries());
       });
 
-      connection.receive('query:refetch', (queryHash, responder) => {
+      connection.receive('query:refetch', ({ queryHash }, responder) => {
         getQueryByHash(queryHash)?.fetch();
         responder.success();
       });
-      connection.receive('query:remove', (queryHash, responder) => {
+      connection.receive('query:remove', ({ queryHash }, responder) => {
         queryCache.removeQueries((query) => query.queryHash === queryHash);
         responder.success();
       });


### PR DESCRIPTION
Ref. https://github.com/facebook/flipper/issues/1142#issuecomment-625314079

Closes #7.