### PR TITLE
Adding the root Readme for the monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# react-query-native-devtools
+Bringing the [React Query Devtools](https://react-query.tanstack.com/docs/devtools) experience to React Native
+
+This is a monorepo for two packages:
+
+### [react-query-native-devtools](./packages/react-query-native-devtools)
+The package for your React Native project to work with React Query.
+Installation and usage are [here](./packages/react-query-native-devtools/README.md).
+
+### [flipper-plugin-react-query-native-devtools](./packages/flipper-plugin-react-query-native-devtools)
+Plugin for the flipper. To use - search for the `flipper-plugin-react-query-native-devtools` in the plugin menu.
+
+More details is [here](./packages/flipper-plugin-react-query-native-devtools/README.md).


### PR DESCRIPTION
Hello! 👋  Thanks for the project!

Problem:
The link in the React Query [docs](https://react-query.tanstack.com/docs/devtools) are leading to the monorepo, but the monorepo has no Readme, it brings confusion.

Solution:
Have a Readme file for monorepo

Linked with #17 