### PR TITLE
Add plugin title for better UX

### DIFF
--- a/packages/flipper-plugin-react-query-native-devtools/package.json
+++ b/packages/flipper-plugin-react-query-native-devtools/package.json
@@ -3,6 +3,7 @@
   "name": "flipper-plugin-react-query-native-devtools",
   "id": "flipper-plugin-react-query-native-devtools",
   "description": "Inspect React Query cache with Flipper",
+  "title": "React Query Devtools",
   "version": "4.1.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "src/index.tsx",


### PR DESCRIPTION
Now the plugin title in Flipper uses the machine name of the plugin which looks not useful. Let's give a better name

![image](https://user-images.githubusercontent.com/539090/174773808-bc1d8137-ac4a-4a0a-9e07-099a26c694da.png)
