### PR TITLE
check observers is not nullish before access

### DIFF
--- a/packages/flipper-plugin-react-query-native-devtools/src/utils/index.ts
+++ b/packages/flipper-plugin-react-query-native-devtools/src/utils/index.ts
@@ -19,13 +19,13 @@ export function formatTimestamp(timestamp: number): string {
 export function getObserversCounter(query: Query): number {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   /* @ts-ignore */
-  return query.observers.length;
+  return query.observers?.length ?? 0;
 }
 
 export function isQueryActive(query: Query): boolean {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   /* @ts-ignore */
-  return query.observers.some((observer) => observer.options.enabled !== false);
+  return query.observers?.some((observer) => observer.options.enabled !== false) ?? false;
 }
 
 export function makeQuerySelectionKey(query: Query): string {


### PR DESCRIPTION
to work with v5 of the react query

@ericledonge
@bgaleotti 

https://github.com/bgaleotti/react-query-native-devtools/issues/113

you can check it in this file

[flipper-plugin-react-query-native-devtools-v4.1.4.tgz](https://github.com/bgaleotti/react-query-native-devtools/files/13215211/flipper-plugin-react-query-native-devtools-v4.1.4.tgz)

![image](https://github.com/bgaleotti/react-query-native-devtools/assets/39925212/a860b9a8-14f7-40a4-8e6a-47b9b2d47aa7)

